### PR TITLE
Updated readme; fixes usage of port 8080 with jwilder/nginx-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ services:
     environment:
       - VIRTUAL_HOST=myolddomain.net
       - REDIRECT_TARGET=mydomain.net
+      - VIRTUAL_PORT=8080
 ```
 
 ### Build the image yourself ###


### PR DESCRIPTION
Since you changed to port 80, the docker-compose example needs to be updated